### PR TITLE
global: addition of cli command for schema validation

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,2 +1,9 @@
 Installation
 ============
+Invenio's DoSchema module is on PyPI so all you need is:
+
+.. code-block:: console
+
+    $ pip install doschema
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,6 @@ from __future__ import print_function
 
 import os
 
-import sphinx.environment
-
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,6 +22,7 @@
     as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
+=====
 Usage
 =====
 

--- a/doschema/__init__.py
+++ b/doschema/__init__.py
@@ -22,7 +22,72 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""JSON Schema utility functions and commands."""
+r"""JSON Schema utility functions and commands.
+
+Compatibility Validation
+-------------------------
+
+It validates compatibility between different JSON schemas versions.
+
+A schema is backward compatible if the fields' type remain the same in all
+JSON schemas declaring it and JSON schemas are type consistent within
+themselves too.
+
+>>> import json
+>>> from io import open
+>>>
+>>> import doschema.validation
+>>> from doschema.utils import detect_encoding
+>>>
+>>> schemas = [
+...     './examples/jsonschema_for_repetition.json',
+...     './examples/jsonschema_repetition.json'
+... ]
+>>>
+>>> schema_validator = doschema.validation.JSONSchemaValidator()
+>>> for schema in schemas:
+...     with open(schema, 'rb') as infile:
+...         byte_file = infile.read()
+...         encoding = detect_encoding(byte_file)
+...         string_file = byte_file.decode(encoding)
+...         json_schema = json.loads(string_file)
+...         schema_validator.validate(json_schema, schema)
+
+By default the index of "array" "items" are ignored. Thus all the values of
+an array should have the same type in order to be compatible.
+This behavior can be disabled by setting "ignore_index = False" in the
+validator's constructor.
+
+>>> import json
+>>> from io import open
+>>>
+>>> import doschema.validation
+>>> from doschema.utils import detect_encoding
+>>>
+>>> schemas = [
+...     './examples/jsonschema_with_index_option.json'
+... ]
+>>>
+>>> schema_validator = doschema.validation.JSONSchemaValidator(
+...     ignore_index = False
+... )
+>>> for schema in schemas:
+...     with open(schema, 'rb') as infile:
+...         byte_file = infile.read()
+...         encoding = detect_encoding(byte_file)
+...         string_file = byte_file.decode(encoding)
+...         json_schema = json.loads(string_file)
+...         schema_validator.validate(json_schema, schema)
+
+CLI usage
+--------------
+.. code-block:: console
+
+    $ doschema validate jsonschema_for_repetition.json \
+    jsonschema_repetition.json
+    $ doschema validate jsonschema_with_index_option.json --with_index
+
+"""
 
 from __future__ import absolute_import, print_function
 

--- a/doschema/cli.py
+++ b/doschema/cli.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoSchema.
+# Copyright (C) 2016 CERN.
+#
+# DoSchema is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# DoSchema is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DoSchema; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""CLI commands."""
+
+import json
+from io import open
+
+import click
+
+import doschema.validation
+from doschema.errors import JSONSchemaCompatibilityError
+from doschema.utils import detect_encoding
+
+
+@click.group()
+def cli():
+    """CLI group."""
+    pass  # pragma: no cover
+
+
+@cli.command()
+@click.argument(
+    'schemas',
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True
+    ),
+    nargs=-1
+)
+@click.option(
+    '--ignore_index/--with_index',
+    default=True,
+    help="Enable/Disable conflict detection between different indices of "
+    "array fields in JSON-Schemas. Enabled by default."
+)
+def validate(schemas, ignore_index):
+    """Main function for cli."""
+    try:
+        schema_validator = doschema.validation.JSONSchemaValidator(
+            ignore_index)
+        for schema in schemas:
+            with open(schema, 'rb') as infile:
+                byte_file = infile.read()
+                encoding = detect_encoding(byte_file)
+                string_file = byte_file.decode(encoding)
+                json_schema = json.loads(string_file)
+                schema_validator.validate(json_schema, schema)
+    except JSONSchemaCompatibilityError as e:
+        raise click.ClickException(str(e))

--- a/doschema/errors.py
+++ b/doschema/errors.py
@@ -39,9 +39,15 @@ class JSONSchemaCompatibilityError(DoSchemaError):
 
     def __init__(self, err_msg, schema, prev_schema=None):
         """Constructor."""
-        super(JSONSchemaCompatibilityError, self).__init__(err_msg)
-        """Error message."""
-        self.schema = schema
-        """Index of schema in which field occurs now."""
         self.prev_schema = prev_schema
         """Index of schema in which field has occured before."""
+        self.schema = schema
+        """Index of schema in which field occurs now."""
+        super(JSONSchemaCompatibilityError, self).__init__(err_msg)
+        """Error message."""
+
+
+class EncodingError(DoSchemaError):
+    """Exception raised when file encoding is not compatible."""
+
+    pass

--- a/doschema/transform.py
+++ b/doschema/transform.py
@@ -25,6 +25,7 @@
 """Transformation module."""
 
 import copy
+
 import jsonschema
 import six
 

--- a/doschema/utils.py
+++ b/doschema/utils.py
@@ -22,31 +22,16 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+"""Utils module."""
 
-# Generate this manifest file by running the following commands:
-#
-#  git init
-#  git add -A
-#  pip install -e .[all]
-#  check-manifest -u
+import chardet
 
-# Check manifest will not automatically add these two files:
-include .dockerignore
-include .editorconfig
 
-# added by check_manifest.py
-include *.rst
-include *.sh
-include *.txt
-include docs/requirements.txt
-include *.json
-include LICENSE
-include pytest.ini
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.py
-recursive-include examples *.json
-recursive-include tests *.py
-recursive-include tests *.json
+def detect_encoding(byte_file):
+    """Detect encoding of a file with schema."""
+    encoding = chardet.detect(byte_file)['encoding']
+    if encoding in ['UTF-16BE', 'UTF-16LE']:
+        encoding = 'UTF-16'
+    elif encoding in ['UTF-32BE', 'UTF-32LE']:
+        encoding = 'UTF-32'
+    return encoding

--- a/doschema/validation.py
+++ b/doschema/validation.py
@@ -47,7 +47,8 @@ class JSONSchemaValidator(object):
         "complex": "number",
         "NoneType": "null",
         "dict": "object",
-        "str": "string"
+        "str": "string",
+        "unicode": "string",
     }
 
     def __init__(self, ignore_index=True, resolver_factory=False):

--- a/examples/cli_example_ignore_option.py
+++ b/examples/cli_example_ignore_option.py
@@ -23,30 +23,35 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-# Generate this manifest file by running the following commands:
-#
-#  git init
-#  git add -A
-#  pip install -e .[all]
-#  check-manifest -u
+"""In this example, there is no option set, so by default
+"--ignore_index" option is enabled.
+Thus array indexes are ignored and for each array field, all items have to be
+of the same type.
 
-# Check manifest will not automatically add these two files:
-include .dockerignore
-include .editorconfig
+Run this example:
+.. code-block:: console
+    $ cd examples
+    $ python app.py
+The same result could be created with the cli:
+.. code-block:: console
+    $ doschema file1.json file2.json
+"""
 
-# added by check_manifest.py
-include *.rst
-include *.sh
-include *.txt
-include docs/requirements.txt
-include *.json
-include LICENSE
-include pytest.ini
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.py
-recursive-include examples *.json
-recursive-include tests *.py
-recursive-include tests *.json
+import json
+from io import open
+
+import doschema.validation
+from doschema.utils import detect_encoding
+
+schemas = [
+    './examples/jsonschema_ignore_index_option.json'
+]
+
+schema_validator = doschema.validation.JSONSchemaValidator()
+for schema in schemas:
+    with open(schema, 'rb') as infile:
+        byte_file = infile.read()
+        encoding = detect_encoding(byte_file)
+        string_file = byte_file.decode(encoding)
+        json_schema = json.loads(string_file)
+        schema_validator.validate(json_schema, schema)

--- a/examples/cli_example_with_option.py
+++ b/examples/cli_example_with_option.py
@@ -23,30 +23,34 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-# Generate this manifest file by running the following commands:
-#
-#  git init
-#  git add -A
-#  pip install -e .[all]
-#  check-manifest -u
+"""In this example, "with_index" option is enabled.
+Thus, types in arrays will be checked with their indexes and items of the same
+array can have different types.
 
-# Check manifest will not automatically add these two files:
-include .dockerignore
-include .editorconfig
+Run this example:
+.. code-block:: console
+    $ cd examples
+    $ python app.py
+The same result could be created with the cli:
+.. code-block:: console
+    $ doschema file1.json file2.json --with_index
+"""
 
-# added by check_manifest.py
-include *.rst
-include *.sh
-include *.txt
-include docs/requirements.txt
-include *.json
-include LICENSE
-include pytest.ini
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.py
-recursive-include examples *.json
-recursive-include tests *.py
-recursive-include tests *.json
+import json
+from io import open
+
+import doschema.validation
+from doschema.utils import detect_encoding
+
+schemas = [
+    './examples/jsonschema_with_index_option.json'
+]
+
+schema_validator = doschema.validation.JSONSchemaValidator(ignore_index=False)
+for schema in schemas:
+    with open(schema, 'rb') as infile:
+        byte_file = infile.read()
+        encoding = detect_encoding(byte_file)
+        string_file = byte_file.decode(encoding)
+        json_schema = json.loads(string_file)
+        schema_validator.validate(json_schema, schema)

--- a/examples/jsonschema_for_repetition.json
+++ b/examples/jsonschema_for_repetition.json
@@ -1,0 +1,8 @@
+{
+    "type":"object",
+    "properties": {
+        "abc": {
+            "type":"integer"
+        }
+    }
+}

--- a/examples/jsonschema_ignore_index_option.json
+++ b/examples/jsonschema_ignore_index_option.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "experiment_info": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "field_A": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "field_A": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/examples/jsonschema_no_repetition.json
+++ b/examples/jsonschema_no_repetition.json
@@ -1,0 +1,8 @@
+{
+    "type":"object",
+    "properties": {
+        "abc": {
+            "type":"string"
+        }
+    }
+}

--- a/examples/jsonschema_other_ref.json
+++ b/examples/jsonschema_other_ref.json
@@ -1,0 +1,34 @@
+{
+    "$schema":"http://json-schema.org/draft-04/schema#",
+    "definitions":{
+        "address":{
+            "type":"object",
+            "properties":{
+                "street_address":{
+                    "type":"differenttype"
+                }
+            }
+        }
+    },
+    "type":"object",
+    "properties":{
+        "billing_address":{
+            "$ref":"#/definitions/address"
+        },
+        "shipping_address":{
+            "allOf":[
+                {"$ref":"#/definitions/address"},
+                {
+                    "properties":{
+                        "type":{
+                            "enum":[
+                                "residential",
+                                "business"
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/examples/jsonschema_ref.json
+++ b/examples/jsonschema_ref.json
@@ -1,0 +1,34 @@
+{
+    "$schema":"http://json-schema.org/draft-04/schema#",
+    "definitions":{
+        "address":{
+            "type":"object",
+            "properties":{
+                "street_address":{
+                    "type":"string"
+                }
+            }
+        }
+    },
+    "type":"object",
+    "properties":{
+        "billing_address":{
+            "$ref":"#/definitions/address"
+        },
+        "shipping_address":{
+            "allOf":[
+                {"$ref":"#/definitions/address"},
+                {
+                    "properties":{
+                        "type":{
+                            "enum":[
+                                "residential",
+                                "business"
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/examples/jsonschema_repetition.json
+++ b/examples/jsonschema_repetition.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "abc": {
+      "type": "integer"
+    }
+  }
+}

--- a/examples/jsonschema_with_index_option.json
+++ b/examples/jsonschema_with_index_option.json
@@ -1,0 +1,25 @@
+{
+    "type":"object",
+    "properties":{
+        "experiment_info":{
+            "type":"array",
+            "items":[
+                {
+                    "type":"object",
+                    "properties":{
+                        "field_A":{
+                            "type":"string"
+                        }
+                    }
+                },{
+                    "type":"object",
+                    "properties":{
+                        "field_A":{
+                            "type":"number"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup_requires = [
 
 install_requires = [
     'jsonschema>=2.5.1',
+    'click>=5.1',
+    'chardet>=2.3.0',
+
 ]
 
 packages = find_packages()
@@ -85,6 +88,9 @@ setup(
     include_package_data=True,
     platforms='any',
     entry_points={
+        'console_scripts': [
+            'doschema = doschema.cli:cli',
+        ],
     },
     extras_require=extras_require,
     install_requires=install_requires,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoSchema.
+# Copyright (C) 2016 CERN.
+#
+# DoSchema is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# DoSchema is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with DoSchema; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+import os
+
+from click.testing import CliRunner
+
+from doschema.cli import validate
+
+
+def path_helper(filename):
+    """Make the path for test files."""
+    return os.path.join('.', 'examples', filename)
+
+
+def test_repetition():
+    """Test that adding field with the same type passes."""
+    runner = CliRunner()
+    schemas = [
+        'jsonschema_for_repetition.json',
+        'jsonschema_repetition.json'
+    ]
+
+    files = [path_helper(filename) for filename in schemas]
+    result = runner.invoke(validate, files)
+
+    assert result.exit_code == 0
+
+
+def test_difference():
+    """Test that adding field with different type fails."""
+    runner = CliRunner()
+    schemas = [
+        'jsonschema_for_repetition.json',
+        'jsonschema_no_repetition.json'
+    ]
+
+    files = [path_helper(filename) for filename in schemas]
+    result = runner.invoke(validate, files)
+
+    assert result.exit_code == 1
+
+
+def test_ref():
+    """Test that references works."""
+    runner = CliRunner()
+    schemas = ['jsonschema_ref.json', 'jsonschema_other_ref.json']
+
+    files = [path_helper(filename) for filename in schemas]
+    result = runner.invoke(validate, files)
+
+    assert result.exit_code == 1
+
+
+def test_ignore_option():
+    """Test that with no option "--ignore_index" option  is set."""
+    runner = CliRunner()
+    schemas = ['jsonschema_ignore_index_option.json']
+
+    files = [path_helper(filename) for filename in schemas]
+    result = runner.invoke(validate, files)
+
+    assert result.exit_code == 0
+
+
+def test_with_option():
+    """Test that "--with_index" option references works."""
+    runner = CliRunner()
+    schemas = ['jsonschema_with_index_option.json']
+
+    files = [path_helper(filename) for filename in schemas]
+    files.append('--with_index')
+    result = runner.invoke(validate, files)
+    assert result.exit_code == 0

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -193,6 +193,27 @@ def test_type_conflict_with_dependencies_implied():
         obj.validate(v1, 'first')
 
 
+def test_new_field_in_dependencies_passes():
+    """Test that having a new field in dependencies fails."""
+    v1 = {
+        "type": "object",
+
+        "properties": {
+            "billing_address": {"type": "number"}
+        },
+
+        "dependencies": {
+            "credit_card": {
+                "properties": {
+                    "billing_address": {"type": "number"}
+                }
+            }
+        }
+    }
+    obj = JSONSchemaValidator()
+    obj.validate(v1, 'first')
+
+
 def test_dependencies_not_dict():
     """Test the exception raised when dependencies are neither of type list
     nor a dict."""


### PR DESCRIPTION
- NEW Adds a new command which validates schemas.
  Command comes with an '--ignore_indexes' option.

Signed-off-by: Paulina1 paulina.malgorzata.lach@cern.cech
